### PR TITLE
remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,10 +6,6 @@
     "heroku-postgresql:hobby-dev"
   ],
   "env": {
-    "BUILDPACK_URL": {
-      "description": "heroku buildpack for Golang",
-      "value": "https://github.com/kr/heroku-buildpack-go"
-    },
     "MQTT_BROKER_URL": {
       "description": "mqtt broker url.",
       "value": ""


### PR DESCRIPTION
This isn't required anymore as we officially support Go now: https://blog.heroku.com/archives/2015/7/7/go_support_now_official_on_heroku